### PR TITLE
WIP: modifications XSL PAGE XML to TEI

### DIFF
--- a/xmlpage_to_tei/xmlpage_to_tei.xsl
+++ b/xmlpage_to_tei/xmlpage_to_tei.xsl
@@ -53,14 +53,6 @@
         </xsl:result-document>
     </xsl:template>
 
-    <xsl:template match="pc:Page//pc:TextRegion" name="TextRegion">
-        <xsl:element name="surfaceGrp">
-            <xsl:copy select=".">
-                <xsl:apply-templates/>
-            </xsl:copy>
-        </xsl:element>
-    </xsl:template>
-
     <xsl:template match="//pc:TextRegion">
         <xsl:element name="surfaceGrp">
             <xsl:attribute name="xml:id">

--- a/xmlpage_to_tei/xmlpage_to_tei.xsl
+++ b/xmlpage_to_tei/xmlpage_to_tei.xsl
@@ -1,54 +1,112 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <?xml-stylesheet type="text/xsl"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" 
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs xi xsi pc"
     xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd" xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15">
-    
-    <xsl:output method="xml" indent="yes" encoding="ISO-8859-1"/>
-    
+    xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd"
+    xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15">
+
+    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+
     <xsl:template match="/">
-        <xsl:result-document href="teifromxmlpage.xml" exclude-result-prefixes="xi xsi pc">
+
+        <xsl:variable name="output">
+            <xsl:value-of
+                select="concat(replace(/pc:PcGts/pc:Page/@imageFilename, '.jpg', ''), '-tei.xml')"/>
+        </xsl:variable>
+
+        <xsl:result-document href="{$output}" exclude-result-prefixes="xi xsi pc">
             <TEI>
                 <teiHeader>
                     <fileDesc>
                         <titleStmt>
-                            <title><xsl:value-of select="substring-before(substring-after(document-uri(),'xmlpage_to_tei/'),'.xml')"/></title>
-                            <author><xsl:value-of select="pc:PcGts/pc:Metadata/pc:Creator"/>
+                            <title>
+                                <xsl:value-of
+                                    select="substring-before(substring-after(document-uri(), 'xmlpage_to_tei/'), '.xml')"
+                                />
+                            </title>
+                            <author>
+                                <xsl:value-of select="pc:PcGts/pc:Metadata/pc:Creator"/>
                             </author>
                         </titleStmt>
                         <publicationStmt>
-                            <p></p>
+                            <p/>
                         </publicationStmt>
                         <sourceDesc>
-                            <p></p>
+                            <p/>
                         </sourceDesc>
                     </fileDesc>
                     <revisionDesc>
-                        <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of select="pc:PcGts/pc:Metadata/pc:Created"/></xsl:attribute>Creation</xsl:element>
-                        <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of select="pc:PcGts/pc:Metadata/pc:LastChange"/></xsl:attribute>Last change</xsl:element>
+                        <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of
+                                    select="pc:PcGts/pc:Metadata/pc:Created"
+                            /></xsl:attribute>Creation</xsl:element>
+                        <xsl:element name="change"><xsl:attribute name="when"><xsl:value-of
+                                    select="pc:PcGts/pc:Metadata/pc:LastChange"
+                            /></xsl:attribute>Last change</xsl:element>
                     </revisionDesc>
                 </teiHeader>
                 <sourceDoc>
-                    <xsl:element name="surfaceGrp"><xsl:attribute name="xml:id"><xsl:value-of select="pc:PcGts/pc:Page/pc:TextRegion/@id"/></xsl:attribute>
-                    <surface>
-                        <xsl:element name="graphic">
-                            <xsl:attribute name="url"><xsl:value-of select="pc:PcGts/pc:Page/@imageFilename"></xsl:value-of></xsl:attribute>
-                            <xsl:attribute name="width"><xsl:value-of select="concat(pc:PcGts/pc:Page/@imageWidth,'px')"/></xsl:attribute>
-                            <xsl:attribute name="height"><xsl:value-of select="concat(pc:PcGts/pc:Page/@imageHeight,'px')"/></xsl:attribute>
-                        </xsl:element>
-                        <xsl:for-each select="pc:PcGts/pc:Page/pc:TextRegion/pc:TextLine">
-                            <xsl:element name="zone"><xsl:attribute name="xml:id"><xsl:value-of select="@id"/></xsl:attribute>
-                                <xsl:attribute name="points"><xsl:value-of select="pc:Coords/@points"/></xsl:attribute>
-                            <xsl:element name="line"><xsl:value-of select="pc:TextEquiv/pc:Unicode"/></xsl:element>
-                            </xsl:element>
-                        </xsl:for-each>
-                    </surface>
-                    </xsl:element>
+                    <xsl:apply-templates select="//pc:Page"/>
                 </sourceDoc>
             </TEI>
         </xsl:result-document>
     </xsl:template>
+
+    <xsl:template match="pc:Page//pc:TextRegion" name="TextRegion">
+        <xsl:element name="surfaceGrp">
+            <xsl:copy select=".">
+                <xsl:apply-templates/>
+            </xsl:copy>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//pc:TextRegion">
+        <xsl:element name="surfaceGrp">
+            <xsl:attribute name="xml:id">
+                <xsl:value-of select="@id"/>
+            </xsl:attribute>
+            <xsl:attribute name="type">
+                <xsl:choose>
+                    <xsl:when test="@custom">
+                        <xsl:value-of select="replace(@custom, ' ', '_')"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of>no_value</xsl:value-of>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <surface>
+                <xsl:element name="graphic">
+                    <xsl:attribute name="url">
+                        <xsl:value-of select="ancestor::pc:PcGts/pc:Page/@imageFilename"/>
+                    </xsl:attribute>
+                    <xsl:attribute name="width">
+                        <xsl:value-of select="concat(ancestor::pc:PcGts/pc:Page/@imageWidth, 'px')"
+                        />
+                    </xsl:attribute>
+                    <xsl:attribute name="height">
+                        <xsl:value-of select="concat(ancestor::pc:PcGts/pc:Page/@imageHeight, 'px')"
+                        />
+                    </xsl:attribute>
+                </xsl:element>
+                <xsl:for-each select="pc:TextLine">
+                    <xsl:element name="zone">
+                        <xsl:attribute name="xml:id">
+                            <xsl:value-of select="@id"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="points">
+                            <xsl:value-of select="pc:Coords/@points"/>
+                        </xsl:attribute>
+                        <xsl:element name="line">
+                            <xsl:value-of select="pc:TextEquiv/pc:Unicode"/>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:for-each>
+            </surface>
+        </xsl:element>
+    </xsl:template>
+
     <!-- pc:PcGts/pc:Page/pc:TextRegion/pc:TextLine/pc:Baseline's missing, I didn't know where to put it -->
 
 </xsl:stylesheet>


### PR DESCRIPTION
Bonjour Manon ! 

On a utilisé ta feuille de transformation PAGE XML vers TEI avec @alix-tz dans le cadre du projet LECTAUREP, merci beaucoup de nous l'avoir partagé, on est très content du résultat :+1: 

Je te propose quelques modifications basées sur les essais de transformation qu'on a fait, les voici : 

* L'output xml TEI est maintenant nommé d'après l'input xml page, en lui rajoutant "-tei". `{nom_numérisation}-tei.xml`

* Pour chaque `<TextRegion>` dans le PAGE XML, on crée un `<surfaceGrp>` en TEI.

* On ajoute un attribut `@type` dans la balise `<surfaceGrp>` qui prend la valeur de l'attribut `@custom` de la balise `<TextRegion>` :arrow_right: à voir si on garde cette modification.

:arrow_right: La valeur de `@custom` dans la balise `<TextRegion>` prend la forme suivante : 'structure {type:col_3;}'. Elle indique le nom de la région à laquelle sont associées les lignes dans eScriptorium. Pour respecter les règles de la TEI, `@type` ne peut pas contenir d'espace. Celui-ci est donc supprimé et remplacé par un '_' dans la XSL.

* S'il manque cet attribut car des lignes n'ont pas été associées à des régions, l'attribut `@type` de `<surfaceGrp>` prend comme valeur `no_value`. Valeur à confirmer cependant.

Le `<sourceDoc>` s'apparente donc maintenant à :

```XML
<sourceDoc>
   <surfaceGrp xml:id="eSc_textblock_6984bc2b" type="structure_{type:col_3;}">
      <surface>
         ...
      </surface>
   </surfaceGrp>
   <surfaceGrp xml:id="eSc_textblock_528630e0" type="structure_{type:col_5;}">
      <surface>
         ...
      </surface>
   </surfaceGrp>
   ...
</sourceDoc>
```

* Et dernièrement, l'encodage de l'output a été changé en UTF-8

Je te souhaite un très bon weekend et encore merci ! 